### PR TITLE
Ajustes para realizar leitura de datas Excel (xls e xlsx)

### DIFF
--- a/src/main/java/br/com/tecsinapse/exporter/importer/ExcelParser.java
+++ b/src/main/java/br/com/tecsinapse/exporter/importer/ExcelParser.java
@@ -326,7 +326,6 @@ public class ExcelParser<T> implements Parser<T> {
                 } catch (NoSuchMethodException e) {
                     TableCellConverter<?> converter = tcm.converter().newInstance();
                     method.invoke(instance, converter.apply(value));
-                    e.printStackTrace();
                 }
             }
             list.add(instance);

--- a/src/main/java/br/com/tecsinapse/exporter/importer/ExcelParser.java
+++ b/src/main/java/br/com/tecsinapse/exporter/importer/ExcelParser.java
@@ -87,7 +87,7 @@ public class ExcelParser<T> implements Parser<T> {
     private String dateTimeStringPattern;
     private ImporterXLSXType importerXLSXType = DEFAULT;
     private boolean dateAsLocalDateTime = false;
-	private boolean dateAsString = true;
+    private boolean dateAsString = true;
 
     //lazy somente criado ao chamar getWorkbook
     private Workbook workbook;
@@ -118,11 +118,11 @@ public class ExcelParser<T> implements Parser<T> {
     }
 
     public ExcelParser(Class<T> clazz, InputStream inputStream, ExcelType type, int afterLine) {
-		this(clazz, inputStream, type, afterLine, Default.class);
+        this(clazz, inputStream, type, afterLine, Default.class);
     }
 
     public ExcelParser(Class<T> clazz, InputStream inputStream, ExcelType type, int afterLine, Class<?> group) {
-		this(clazz, inputStream, type, afterLine, false, ImporterXLSXType.DEFAULT, group);
+        this(clazz, inputStream, type, afterLine, false, ImporterXLSXType.DEFAULT, group);
     }
 
     public ExcelParser(Class<T> clazz, InputStream inputStream, ExcelType type, int afterLine, boolean isLastSheet, ImporterXLSXType importerXLSXType) {
@@ -162,25 +162,25 @@ public class ExcelParser<T> implements Parser<T> {
         this.afterLine = afterLine;
     }
 
-	public void setSheetNumber(int sheetNumber) {
-		this.sheetNumber = sheetNumber;
-	}
+    public void setSheetNumber(int sheetNumber) {
+        this.sheetNumber = sheetNumber;
+    }
 
-	public int getSheetNumber() {
-		return sheetNumber;
-	}
+    public int getSheetNumber() {
+        return sheetNumber;
+    }
 
-	public void setSheetNumberAsFirstNotHidden() {
-		if (type == ExcelType.XLSX) {
-			try {
-				sheetNumber = new XSSFWorkbook(getOPCPackage()).getFirstVisibleTab();
-			} catch (IOException e) {
-				throw Throwables.propagate(e);
-			}
-		} else {
-			sheetNumber = getWorkbook().getFirstVisibleTab();
-		}
-	}
+    public void setSheetNumberAsFirstNotHidden() {
+        if (type == ExcelType.XLSX) {
+            try {
+                sheetNumber = new XSSFWorkbook(getOPCPackage()).getFirstVisibleTab();
+            } catch (IOException e) {
+                throw Throwables.propagate(e);
+            }
+        } else {
+            sheetNumber = getWorkbook().getFirstVisibleTab();
+        }
+    }
 
     @Override
     public int getNumberOfSheets() {
@@ -214,77 +214,77 @@ public class ExcelParser<T> implements Parser<T> {
         return resultList;
     }
 
-	private void removeBlankLinesOfEnd(List<T> resultList) throws InvocationTargetException, IllegalAccessException, IntrospectionException {
+    private void removeBlankLinesOfEnd(List<T> resultList) throws InvocationTargetException, IllegalAccessException, IntrospectionException {
         Collections.reverse(resultList);
-		final PropertyDescriptor[] propertyDescriptors = Introspector.getBeanInfo(clazz).getPropertyDescriptors();
-		final Set<Method> readMethodsOfWriteMethodsWithTableCellMapping = FluentIterable.from(Arrays.asList(propertyDescriptors))
-				.filter(hasWriteAndReadMethod())
-				.filter(hasAnnotationTableCellMapping())
-				.transform(toReadMethod())
-				.toSet();
+        final PropertyDescriptor[] propertyDescriptors = Introspector.getBeanInfo(clazz).getPropertyDescriptors();
+        final Set<Method> readMethodsOfWriteMethodsWithTableCellMapping = FluentIterable.from(Arrays.asList(propertyDescriptors))
+                .filter(hasWriteAndReadMethod())
+                .filter(hasAnnotationTableCellMapping())
+                .transform(toReadMethod())
+                .toSet();
 
-		if (!readMethodsOfWriteMethodsWithTableCellMapping.isEmpty()) {
-			final Iterator<T> iterator = resultList.iterator();
-			while(iterator.hasNext()) {
-				final T instance = iterator.next();
-				if (allPropertiesHasNoValue(instance, readMethodsOfWriteMethodsWithTableCellMapping)) {
-					iterator.remove();
-				} else {
-					break;
-				}
-			}
-		}
+        if (!readMethodsOfWriteMethodsWithTableCellMapping.isEmpty()) {
+            final Iterator<T> iterator = resultList.iterator();
+            while (iterator.hasNext()) {
+                final T instance = iterator.next();
+                if (allPropertiesHasNoValue(instance, readMethodsOfWriteMethodsWithTableCellMapping)) {
+                    iterator.remove();
+                } else {
+                    break;
+                }
+            }
+        }
         Collections.reverse(resultList);
-	}
+    }
 
-	private static Function<PropertyDescriptor, Method> toReadMethod() {
-		return new Function<PropertyDescriptor, Method>() {
-			@Override
-			public Method apply(PropertyDescriptor propertyDescriptor) {
-				return propertyDescriptor.getReadMethod();
-			}
-		};
-	}
+    private static Function<PropertyDescriptor, Method> toReadMethod() {
+        return new Function<PropertyDescriptor, Method>() {
+            @Override
+            public Method apply(PropertyDescriptor propertyDescriptor) {
+                return propertyDescriptor.getReadMethod();
+            }
+        };
+    }
 
-	private boolean allPropertiesHasNoValue(T instance, Set<Method> readMethodsOfWriteMethodsWithTableCellMapping) throws InvocationTargetException, IllegalAccessException {
-		for (Method method : readMethodsOfWriteMethodsWithTableCellMapping) {
-			final Object value = method.invoke(instance);
-			if (method.getReturnType().equals(String.class)) {
-				String valueStr = nullToEmpty((String) value).trim();
-				if (!isNullOrEmpty(valueStr)) {
-					return false;
-				}
-			} else if (value != null) {
-				return false;
-			}
-		}
-		return true;
-	}
+    private boolean allPropertiesHasNoValue(T instance, Set<Method> readMethodsOfWriteMethodsWithTableCellMapping) throws InvocationTargetException, IllegalAccessException {
+        for (Method method : readMethodsOfWriteMethodsWithTableCellMapping) {
+            final Object value = method.invoke(instance);
+            if (method.getReturnType().equals(String.class)) {
+                String valueStr = nullToEmpty((String) value).trim();
+                if (!isNullOrEmpty(valueStr)) {
+                    return false;
+                }
+            } else if (value != null) {
+                return false;
+            }
+        }
+        return true;
+    }
 
-	private Predicate<PropertyDescriptor> hasAnnotationTableCellMapping() {
-		return new Predicate<PropertyDescriptor>() {
-			@Override
-			public boolean apply(PropertyDescriptor propertyDescriptor) {
-				final Method writeMethod = propertyDescriptor.getWriteMethod();
-				for (Annotation annotation : writeMethod.getDeclaredAnnotations()) {
-					if (annotation instanceof TableCellMapping) {
-						return true;
-					}
-				}
-				return false;
-			}
-		};
-	}
+    private Predicate<PropertyDescriptor> hasAnnotationTableCellMapping() {
+        return new Predicate<PropertyDescriptor>() {
+            @Override
+            public boolean apply(PropertyDescriptor propertyDescriptor) {
+                final Method writeMethod = propertyDescriptor.getWriteMethod();
+                for (Annotation annotation : writeMethod.getDeclaredAnnotations()) {
+                    if (annotation instanceof TableCellMapping) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+        };
+    }
 
-	private Predicate<PropertyDescriptor> hasWriteAndReadMethod() {
-		return new Predicate<PropertyDescriptor>() {
-			@Override
-			public boolean apply(PropertyDescriptor propertyDescriptor) {
-				return propertyDescriptor.getWriteMethod() != null &&
-						propertyDescriptor.getReadMethod() != null;
-			}
-		};
-	}
+    private Predicate<PropertyDescriptor> hasWriteAndReadMethod() {
+        return new Predicate<PropertyDescriptor>() {
+            @Override
+            public boolean apply(PropertyDescriptor propertyDescriptor) {
+                return propertyDescriptor.getWriteMethod() != null &&
+                        propertyDescriptor.getReadMethod() != null;
+            }
+        };
+    }
 
     private List<T> parseXlsx() throws Exception {
         List<List<String>> xlsxLines = getXlsxLines(afterLine, sheetNumber);
@@ -301,7 +301,7 @@ public class ExcelParser<T> implements Parser<T> {
 
                 Method method = methodTcm.getKey();
                 method.setAccessible(true);
-                
+
                 TableCellMapping tcm = methodTcm.getValue();
                 String value = getValueOrEmpty(fields, tcm.columnIndex());
                 TableCellConverter<?> converter = tcm.converter().newInstance();
@@ -322,8 +322,8 @@ public class ExcelParser<T> implements Parser<T> {
 
         final FormulaEvaluator evaluator = workbook.getCreationHelper().createFormulaEvaluator();
 
-		final Constructor<T> constructor = clazz.getDeclaredConstructor();
-		constructor.setAccessible(true);
+        final Constructor<T> constructor = clazz.getDeclaredConstructor();
+        constructor.setAccessible(true);
 
         Iterator<Row> rowIterator = sheet.iterator();
 
@@ -337,35 +337,35 @@ public class ExcelParser<T> implements Parser<T> {
             T instance = constructor.newInstance();
 
             for (Entry<Method, TableCellMapping> methodTcm : cellMappingByMethod.entrySet()) {
-                
+
                 TableCellMapping tcm = methodTcm.getValue();
                 Method method = methodTcm.getKey();
                 method.setAccessible(true);
-                
+
                 Object value = getValueOrEmptyAsObject(evaluator, row.getCell(tcm.columnIndex()));
-				try {
-					if (!dateAsString && isSameType(value, tcm.converter())) {
-						method.invoke(instance, value);
-					} else {
-						TableCellConverter<?> converter = tcm.converter().newInstance();
-						method.invoke(instance, converter.apply(value.toString()));
-					}
-				} catch (NoSuchMethodException e) {
-					TableCellConverter<?> converter = tcm.converter().newInstance();
-					method.invoke(instance, converter.apply(value.toString()));
-				}
+                try {
+                    if (!dateAsString && isSameType(value, tcm.converter())) {
+                        method.invoke(instance, value);
+                    } else {
+                        TableCellConverter<?> converter = tcm.converter().newInstance();
+                        method.invoke(instance, converter.apply(value.toString()));
+                    }
+                } catch (NoSuchMethodException e) {
+                    TableCellConverter<?> converter = tcm.converter().newInstance();
+                    method.invoke(instance, converter.apply(value.toString()));
+                }
             }
             list.add(instance);
         }
         return list;
     }
 
-	private boolean isSameType(Object value, Class<?> converter) throws NoSuchMethodException {
-		Method converterMethod = converter.getMethod("apply", String.class);
-		Class<?> returnType = converterMethod.getReturnType();
-		boolean isInstance = value != null && returnType.isInstance(value);
-		return isInstance;
-	}
+    private boolean isSameType(Object value, Class<?> converter) throws NoSuchMethodException {
+        Method converterMethod = converter.getMethod("apply", String.class);
+        Class<?> returnType = converterMethod.getReturnType();
+        boolean isInstance = value != null && returnType.isInstance(value);
+        return isInstance;
+    }
 
     private String getValueOrEmpty(List<String> fields, int index) {
         if (fields.isEmpty() || fields.size() <= index) {
@@ -375,7 +375,7 @@ public class ExcelParser<T> implements Parser<T> {
     }
 
     public List<List<String>> getLines() throws Exception {
-        if(type == ExcelType.XLSX){
+        if (type == ExcelType.XLSX) {
             return getXlsxLines(afterLine, sheetNumber);
         }
         return getXlsLinesIncludingEmptyCells();
@@ -426,7 +426,7 @@ public class ExcelParser<T> implements Parser<T> {
             final Row row = linhasArquivo.get(i);
 
             List<String> cellsStringValues = Lists.newArrayList();
-            for(int index = 0; index < row.getLastCellNum(); index++) {
+            for (int index = 0; index < row.getLastCellNum(); index++) {
                 Cell cell = row.getCell(index, Row.CREATE_NULL_AS_BLANK);
                 cellsStringValues.add(getValueOrEmpty(evaluator, cell));
             }
@@ -435,9 +435,9 @@ public class ExcelParser<T> implements Parser<T> {
         return lines;
     }
 
-	private String getValueOrEmpty(FormulaEvaluator evaluator, Cell cell) {
-		return getValueOrEmptyAsObject(evaluator, cell).toString();
-	}
+    private String getValueOrEmpty(FormulaEvaluator evaluator, Cell cell) {
+        return getValueOrEmptyAsObject(evaluator, cell).toString();
+    }
 
     private Object getValueOrEmptyAsObject(FormulaEvaluator evaluator, Cell cell) {
         final CellValue cellValue = evaluator.evaluate(cell);
@@ -450,11 +450,11 @@ public class ExcelParser<T> implements Parser<T> {
             case Cell.CELL_TYPE_NUMERIC:
                 if (DateUtil.isCellDateFormatted(cell)) {
                     if (dateAsLocalDateTime) {
-						LocalDateTime localDateTime = LocalDateTime.fromDateFields(cell.getDateCellValue());
+                        LocalDateTime localDateTime = LocalDateTime.fromDateFields(cell.getDateCellValue());
                         return dateAsString ? localDateTime.toString(dateTimeStringPattern) : localDateTime;
                     }
-					LocalDate localDate = new LocalDate(cell.getDateCellValue());
-                    return  dateAsString ? localDate.toString(dateStringPattern) : localDate;
+                    LocalDate localDate = new LocalDate(cell.getDateCellValue());
+                    return dateAsString ? localDate.toString(dateStringPattern) : localDate;
                 }
                 //força a tirar '.0' se for inteiro
                 cell.setCellType(Cell.CELL_TYPE_STRING);
@@ -527,7 +527,7 @@ public class ExcelParser<T> implements Parser<T> {
                 continue;
             }
 
-			table = processXlsxSheet(styles, strings, stream, initialRow);
+            table = processXlsxSheet(styles, strings, stream, initialRow);
 
             stream.close();
             //le apenas 1 aba
@@ -542,66 +542,66 @@ public class ExcelParser<T> implements Parser<T> {
         final Table table = processXlsxSheet(styles, strings, sheetInputStream);
 
         if (ignoreFirstRow) {
-        	table.removeFirstRow();
-		}
+            table.removeFirstRow();
+        }
 
         return table;
     }
 
 
-	protected Table processXlsxSheet(StylesTable styles, ReadOnlySharedStringsTable strings, InputStream sheetInputStream, int rowInitial) throws Exception {
+    protected Table processXlsxSheet(StylesTable styles, ReadOnlySharedStringsTable strings, InputStream sheetInputStream, int rowInitial) throws Exception {
 
-		final Table table = processXlsxSheet(styles, strings, sheetInputStream);
+        final Table table = processXlsxSheet(styles, strings, sheetInputStream);
 
-		table.removeInitialRows(rowInitial);
+        table.removeInitialRows(rowInitial);
 
-		return table;
-	}
+        return table;
+    }
 
-	private Table processXlsxSheet(StylesTable styles, ReadOnlySharedStringsTable strings, InputStream sheetInputStream) throws Exception {
+    private Table processXlsxSheet(StylesTable styles, ReadOnlySharedStringsTable strings, InputStream sheetInputStream) throws Exception {
 
-		final Table table = new Table();
-		InputSource sheetSource = new InputSource(sheetInputStream);
-		SAXParserFactory saxFactory = SAXParserFactory.newInstance();
-		SAXParser saxParser = saxFactory.newSAXParser();
-		XMLReader sheetParser = saxParser.getXMLReader();
+        final Table table = new Table();
+        InputSource sheetSource = new InputSource(sheetInputStream);
+        SAXParserFactory saxFactory = SAXParserFactory.newInstance();
+        SAXParser saxParser = saxFactory.newSAXParser();
+        XMLReader sheetParser = saxParser.getXMLReader();
 
-		ContentHandler handler = new XSSFSheetXMLHandler(styles, strings, new XSSFSheetXMLHandler.SheetContentsHandler() {
+        ContentHandler handler = new XSSFSheetXMLHandler(styles, strings, new XSSFSheetXMLHandler.SheetContentsHandler() {
 
-			@Override
-			public void startRow(int rowNum) {
-				table.addNewRow();
-			}
+            @Override
+            public void startRow(int rowNum) {
+                table.addNewRow();
+            }
 
-			@Override
-			public void endRow() {
-			}
+            @Override
+            public void endRow() {
+            }
 
-			@Override
-			public void cell(String cellReference, String formattedValue) {
-				int columnIndex = ExcelUtil.getColumnIndexByColumnName(cellReference);
-				int idx = table.getNextColumnIndexOfLastRow();
-				int dif = columnIndex - idx;
-				while(dif-- > 0) {
-					table.add("");
-				}
-				table.add(formattedValue);
-			}
+            @Override
+            public void cell(String cellReference, String formattedValue) {
+                int columnIndex = ExcelUtil.getColumnIndexByColumnName(cellReference);
+                int idx = table.getNextColumnIndexOfLastRow();
+                int dif = columnIndex - idx;
+                while (dif-- > 0) {
+                    table.add("");
+                }
+                table.add(formattedValue);
+            }
 
-			@Override
-			public void headerFooter(String text, boolean isHeader, String tagName) {
+            @Override
+            public void headerFooter(String text, boolean isHeader, String tagName) {
 
-			}
+            }
 
-		},
-				importerXLSXType.getFormatter(this),
-				false//means result instead of formula
-		);
-		sheetParser.setContentHandler(handler);
-		sheetParser.parse(sheetSource);
+        },
+                importerXLSXType.getFormatter(this),
+                false//means result instead of formula
+        );
+        sheetParser.setContentHandler(handler);
+        sheetParser.parse(sheetSource);
 
-		return table;
-	}
+        return table;
+    }
 
     @Override
     public void close() throws IOException {
@@ -612,11 +612,11 @@ public class ExcelParser<T> implements Parser<T> {
         this.dateAsLocalDateTime = dateAsLocalDateTime;
     }
 
-	public void setDateAsString(boolean dateAsString) {
-		this.dateAsString = dateAsString;
-	}
+    public void setDateAsString(boolean dateAsString) {
+        this.dateAsString = dateAsString;
+    }
 
-	public boolean isDateAsString() {
-		return dateAsString;
-	}
+    public boolean isDateAsString() {
+        return dateAsString;
+    }
 }

--- a/src/main/java/br/com/tecsinapse/exporter/importer/ExcelParser.java
+++ b/src/main/java/br/com/tecsinapse/exporter/importer/ExcelParser.java
@@ -309,17 +309,17 @@ public class ExcelParser<T> implements Parser<T> {
                 String value = getValueOrEmpty(fields, tcm.columnIndex());
 
                 try {
-                    T obj;
+                    Object obj;
                     if (Strings.isNullOrEmpty(value)) {
                         obj = null;
                     } if (isReturnType(tcm.converter(), LocalDate.class)) {
                         LocalDateTime localDateTime = DateTimeFormat.forPattern(getDateStringPattern()).parseLocalDateTime(value);
-                        obj = (T) localDateTime.toLocalDate();
+                        obj = localDateTime.toLocalDate();
                     } else if (isReturnType(tcm.converter(), LocalDateTime.class)) {
-                        obj = (T) DateTimeFormat.forPattern(getDateStringPattern()).parseLocalDateTime(value);
+                        obj = DateTimeFormat.forPattern(getDateStringPattern()).parseLocalDateTime(value);
                     } else {
                         TableCellConverter converter = tcm.converter().newInstance();
-                        obj = (T) converter.apply(value);
+                        obj = converter.apply(value);
                     }
                     method.invoke(instance, obj);
 

--- a/src/main/java/br/com/tecsinapse/exporter/importer/ImporterXLSXType.java
+++ b/src/main/java/br/com/tecsinapse/exporter/importer/ImporterXLSXType.java
@@ -8,6 +8,7 @@ package br.com.tecsinapse.exporter.importer;
 
 import java.math.BigDecimal;
 import java.util.Date;
+import java.util.Locale;
 
 import org.apache.poi.ss.usermodel.DataFormatter;
 import org.apache.poi.ss.usermodel.DateUtil;
@@ -56,6 +57,7 @@ public enum ImporterXLSXType {
         private final ExcelParser<?> parser;
 
         private DefaultDataFormat(ExcelParser<?> parser) {
+            super(Locale.ENGLISH);
             this.parser = parser;
         }
 

--- a/src/main/java/br/com/tecsinapse/exporter/importer/ImporterXLSXType.java
+++ b/src/main/java/br/com/tecsinapse/exporter/importer/ImporterXLSXType.java
@@ -28,9 +28,6 @@ public enum ImporterXLSXType {
         }
     };
 
-	private ImporterXLSXType() {
-	}
-
     abstract DataFormatter getFormatter(ExcelParser<?> parser);
 
 	private static class UniqueDataFormat extends DataFormatter {

--- a/src/test/java/br/com/tecsinapse/files/test/ExporterFileTest.java
+++ b/src/test/java/br/com/tecsinapse/files/test/ExporterFileTest.java
@@ -12,17 +12,18 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 
-import com.google.common.base.Charsets;
-import com.google.common.base.Function;
-import com.google.common.base.Supplier;
-import com.google.common.base.Throwables;
-import com.google.common.collect.FluentIterable;
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.xssf.streaming.SXSSFWorkbook;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+
+import com.google.common.base.Charsets;
+import com.google.common.base.Function;
+import com.google.common.base.Supplier;
+import com.google.common.base.Throwables;
+import com.google.common.collect.FluentIterable;
 
 import br.com.tecsinapse.exporter.CSVUtil;
 import br.com.tecsinapse.exporter.ExcelUtil;

--- a/src/test/java/br/com/tecsinapse/files/test/ExporterFileTest.java
+++ b/src/test/java/br/com/tecsinapse/files/test/ExporterFileTest.java
@@ -6,6 +6,8 @@
  */
 package br.com.tecsinapse.files.test;
 
+import static java.util.Locale.ENGLISH;
+import static java.util.Locale.FRANCE;
 import static org.testng.Assert.assertEquals;
 
 import java.io.File;
@@ -39,6 +41,8 @@ import br.com.tecsinapse.exporter.TableCellType;
 import br.com.tecsinapse.exporter.importer.ExcelParser;
 
 public class ExporterFileTest {
+
+    private static final Locale LC_PT_BR = new Locale("pt","BR");
 
     @DataProvider(name = "beans")
     public Object[][] beans() {
@@ -110,10 +114,22 @@ public class ExporterFileTest {
         });
 
         return new Object[][]{
-                {beans, csvExport, csvLines, "#.#", ""},
-                {beans, xlsExport, excelLines, "#.#", ""},
-                {beans, xlsxExport, excelLines, ".#", ""},
-                {beans, sxlsxExport, excelLines, ".#", ""}
+                {beans, csvExport, csvLines, "#.#", "", Locale.getDefault()},
+                {beans, xlsExport, excelLines, "#.#", "", Locale.getDefault()},
+                {beans, xlsxExport, excelLines, ".#", "", Locale.getDefault()},
+                {beans, sxlsxExport, excelLines, ".#", "", Locale.getDefault()},
+                {beans, csvExport, csvLines, "#.#", "", ENGLISH},
+                {beans, xlsExport, excelLines, "#.#", "", ENGLISH},
+                {beans, xlsxExport, excelLines, ".#", "", ENGLISH},
+                {beans, sxlsxExport, excelLines, ".#", "", ENGLISH},
+                {beans, csvExport, csvLines, "#.#", "", LC_PT_BR},
+                {beans, xlsExport, excelLines, "#.#", "", LC_PT_BR},
+                {beans, xlsxExport, excelLines, ".#", "", LC_PT_BR},
+                {beans, sxlsxExport, excelLines, ".#", "", LC_PT_BR},
+                {beans, csvExport, csvLines, "#.#", "", FRANCE},
+                {beans, xlsExport, excelLines, "#.#", "", FRANCE},
+                {beans, xlsxExport, excelLines, ".#", "", FRANCE},
+                {beans, sxlsxExport, excelLines, ".#", "", FRANCE}
         };
     }
 
@@ -141,9 +157,10 @@ public class ExporterFileTest {
     public void testExporter(
             List<FileBean> beans,
             Function<Table, File> toFile, Function<File, List<List<String>>> toLines,
-            String decimalPattern, String nullValue) throws IOException {
+            String decimalPattern, String nullValue, Locale locale) throws IOException {
+        Locale.setDefault(locale);
         final String dataPattern = "dd/MM/yyyy";
-        final DecimalFormat decimalFormat = new DecimalFormat(decimalPattern, new DecimalFormatSymbols(Locale.getDefault()));
+        final DecimalFormat decimalFormat = new DecimalFormat(decimalPattern, new DecimalFormatSymbols(ENGLISH));
 
 
         final Table table = new Table();

--- a/src/test/java/br/com/tecsinapse/files/test/ExporterFileTest.java
+++ b/src/test/java/br/com/tecsinapse/files/test/ExporterFileTest.java
@@ -7,7 +7,7 @@
 package br.com.tecsinapse.files.test;
 
 import static java.util.Locale.ENGLISH;
-import static java.util.Locale.FRANCE;
+import static java.util.Locale.FRENCH;
 import static org.testng.Assert.assertEquals;
 
 import java.io.File;
@@ -42,7 +42,7 @@ import br.com.tecsinapse.exporter.importer.ExcelParser;
 
 public class ExporterFileTest {
 
-    private static final Locale LC_PT_BR = new Locale("pt","BR");
+    private static final List<Locale> LOCALES = Arrays.asList(new Locale("pt","BR"), ENGLISH, FRENCH, Locale.getDefault());
 
     @DataProvider(name = "beans")
     public Object[][] beans() {
@@ -114,22 +114,10 @@ public class ExporterFileTest {
         });
 
         return new Object[][]{
-                {beans, csvExport, csvLines, "#.#", "", Locale.getDefault()},
-                {beans, xlsExport, excelLines, "#.#", "", Locale.getDefault()},
-                {beans, xlsxExport, excelLines, ".#", "", Locale.getDefault()},
-                {beans, sxlsxExport, excelLines, ".#", "", Locale.getDefault()},
-                {beans, csvExport, csvLines, "#.#", "", ENGLISH},
-                {beans, xlsExport, excelLines, "#.#", "", ENGLISH},
-                {beans, xlsxExport, excelLines, ".#", "", ENGLISH},
-                {beans, sxlsxExport, excelLines, ".#", "", ENGLISH},
-                {beans, csvExport, csvLines, "#.#", "", LC_PT_BR},
-                {beans, xlsExport, excelLines, "#.#", "", LC_PT_BR},
-                {beans, xlsxExport, excelLines, ".#", "", LC_PT_BR},
-                {beans, sxlsxExport, excelLines, ".#", "", LC_PT_BR},
-                {beans, csvExport, csvLines, "#.#", "", FRANCE},
-                {beans, xlsExport, excelLines, "#.#", "", FRANCE},
-                {beans, xlsxExport, excelLines, ".#", "", FRANCE},
-                {beans, sxlsxExport, excelLines, ".#", "", FRANCE}
+                {beans, csvExport, csvLines, "#.#", ""},
+                {beans, xlsExport, excelLines, "#.#", ""},
+                {beans, xlsxExport, excelLines, ".#", ""},
+                {beans, sxlsxExport, excelLines, ".#", ""}
         };
     }
 
@@ -157,83 +145,85 @@ public class ExporterFileTest {
     public void testExporter(
             List<FileBean> beans,
             Function<Table, File> toFile, Function<File, List<List<String>>> toLines,
-            String decimalPattern, String nullValue, Locale locale) throws IOException {
-        Locale.setDefault(locale);
-        final String dataPattern = "dd/MM/yyyy";
-        final DecimalFormat decimalFormat = new DecimalFormat(decimalPattern, new DecimalFormatSymbols(ENGLISH));
+            String decimalPattern, String nullValue) throws IOException {
+        for (Locale locale : LOCALES) {
+            Locale.setDefault(locale);
+            final String dataPattern = "dd/MM/yyyy";
+            final DecimalFormat decimalFormat = new DecimalFormat(decimalPattern, new DecimalFormatSymbols(ENGLISH));
 
 
-        final Table table = new Table();
+            final Table table = new Table();
 
-        //header
-        table.addNewRow();
-        table.add("Cidade", TableCellType.HEADER);
-        table.add("Estado", TableCellType.HEADER);
-        table.add("Data", TableCellType.HEADER);
-        table.add("", TableCellType.HEADER);
-        table.add("Inteiro", TableCellType.HEADER);
-        table.add("Decimal", TableCellType.HEADER);
-
-        for (FileBean bean : beans) {
-            //body
+            //header
             table.addNewRow();
-            table.add(bean.cidade);
-            table.add(bean.estado);
-            table.add(bean.data == null ? "" : bean.data.toString(dataPattern));// exportar em formato data
-            table.add("");
-            table.add(bean.inteiro);
-            table.add(bean.decimal);
-        }
+            table.add("Cidade", TableCellType.HEADER);
+            table.add("Estado", TableCellType.HEADER);
+            table.add("Data", TableCellType.HEADER);
+            table.add("", TableCellType.HEADER);
+            table.add("Inteiro", TableCellType.HEADER);
+            table.add("Decimal", TableCellType.HEADER);
 
-        //teste
-        table.addNewRow();
-        table.add("");
-        table.add(" ");
-        table.add((String) null);
-        table.add((Number) null);
-        table.add("last", TableCellType.FOOTER);
-        table.add(new TableCell("last tc", TableCellType.FOOTER));
-
-
-        final File file = toFile.apply(table);
-        final List<List<String>> lines = toLines.apply(file);
-
-        //asserts
-        assertEquals(1 + beans.size() + 1, lines.size());
-
-        for (int i = 0; i < lines.size(); i++) {
-            final List<String> row = lines.get(i);
-            assertEquals(row.size(), 6);
-
-            if (i == 0) {//header
-                assertEquals(row.get(0), "Cidade");
-                assertEquals(row.get(1), "Estado");
-                assertEquals(row.get(2), "Data");
-                assertEquals(row.get(3), "");
-                assertEquals(row.get(4), "Inteiro");
-                assertEquals(row.get(5), "Decimal");
-
-                continue;
+            for (FileBean bean : beans) {
+                //body
+                table.addNewRow();
+                table.add(bean.cidade);
+                table.add(bean.estado);
+                table.add(bean.data == null ? "" : bean.data.toString(dataPattern));// exportar em formato data
+                table.add("");
+                table.add(bean.inteiro);
+                table.add(bean.decimal);
             }
 
-            if (i <= beans.size()) { // body
-                final FileBean bean = beans.get(i - 1);
+            //teste
+            table.addNewRow();
+            table.add("");
+            table.add(" ");
+            table.add((String) null);
+            table.add((Number) null);
+            table.add("last", TableCellType.FOOTER);
+            table.add(new TableCell("last tc", TableCellType.FOOTER));
 
-                assertEquals(row.get(0), bean.cidade);
-                assertEquals(row.get(1), bean.estado);
-                assertEquals(row.get(2), bean.data == null ? "" : bean.data.toString(dataPattern));
-                assertEquals(row.get(3), "");
-                assertEquals(row.get(4), decimalFormat.format(bean.inteiro));
-                assertEquals(row.get(5), decimalFormat.format(bean.decimal));
 
-            } else {//row teste
+            final File file = toFile.apply(table);
+            final List<List<String>> lines = toLines.apply(file);
 
-                assertEquals(row.get(0), "");
-                assertEquals(row.get(1), " ");
-                assertEquals(row.get(2), nullValue);
-                assertEquals(row.get(3), nullValue);
-                assertEquals(row.get(4), "last");
-                assertEquals(row.get(5), "last tc");
+            //asserts
+            assertEquals(1 + beans.size() + 1, lines.size());
+
+            for (int i = 0; i < lines.size(); i++) {
+                final List<String> row = lines.get(i);
+                assertEquals(row.size(), 6);
+
+                if (i == 0) {//header
+                    assertEquals(row.get(0), "Cidade");
+                    assertEquals(row.get(1), "Estado");
+                    assertEquals(row.get(2), "Data");
+                    assertEquals(row.get(3), "");
+                    assertEquals(row.get(4), "Inteiro");
+                    assertEquals(row.get(5), "Decimal");
+
+                    continue;
+                }
+
+                if (i <= beans.size()) { // body
+                    final FileBean bean = beans.get(i - 1);
+
+                    assertEquals(row.get(0), bean.cidade);
+                    assertEquals(row.get(1), bean.estado);
+                    assertEquals(row.get(2), bean.data == null ? "" : bean.data.toString(dataPattern));
+                    assertEquals(row.get(3), "");
+                    assertEquals(row.get(4), decimalFormat.format(bean.inteiro));
+                    assertEquals(row.get(5), decimalFormat.format(bean.decimal));
+
+                } else {//row teste
+
+                    assertEquals(row.get(0), "");
+                    assertEquals(row.get(1), " ");
+                    assertEquals(row.get(2), nullValue);
+                    assertEquals(row.get(3), nullValue);
+                    assertEquals(row.get(4), "last");
+                    assertEquals(row.get(5), "last tc");
+                }
             }
         }
     }

--- a/src/test/java/br/com/tecsinapse/files/test/ImporterFileTest.java
+++ b/src/test/java/br/com/tecsinapse/files/test/ImporterFileTest.java
@@ -6,6 +6,8 @@
  */
 package br.com.tecsinapse.files.test;
 
+import static java.util.Locale.ENGLISH;
+import static java.util.Locale.FRENCH;
 import static org.testng.Assert.assertEquals;
 
 import java.io.File;
@@ -15,6 +17,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 
 import org.joda.time.LocalDate;
 import org.joda.time.format.DateTimeFormat;
@@ -34,6 +37,8 @@ import br.com.tecsinapse.exporter.importer.ImporterXLSXType;
 public class ImporterFileTest {
 
     private static final String DD_MM_YYYY = "dd/MM/yyyy";
+
+    private static final List<Locale> LOCALES = Arrays.asList(new Locale("pt","BR"), ENGLISH, FRENCH, Locale.getDefault());
 
     public static final class LocalDateConverter implements TableCellConverter<LocalDate> {
 
@@ -66,15 +71,18 @@ public class ImporterFileTest {
 
     @Test(dataProvider = "arquivos")
     public void validaArquivo(File arquivo, int afterLine, FileType esperadoFileType, List<FileBean> esperados) throws Exception {
-        try (final Importer<FileBean> importer = new Importer<>(FileBean.class, Charsets.UTF_8, arquivo)) {
-            importer.setAfterLine(afterLine);
-            importer.setDateStringPattern(DD_MM_YYYY);
+        for (Locale locale : LOCALES) {
+            Locale.setDefault(locale);
+            try (final Importer<FileBean> importer = new Importer<>(FileBean.class, Charsets.UTF_8, arquivo)) {
+                importer.setAfterLine(afterLine);
+                importer.setDateStringPattern(DD_MM_YYYY);
 
-            assertEquals(importer.getFileType(), esperadoFileType);
+                assertEquals(importer.getFileType(), esperadoFileType);
 
-            final List<FileBean> beans = importer.parse();
-            for (int i = 0; i < beans.size(); i++) {
-                assertFileBeanEquals(beans.get(i), esperados.get(i), arquivo);
+                final List<FileBean> beans = importer.parse();
+                for (int i = 0; i < beans.size(); i++) {
+                    assertFileBeanEquals(beans.get(i), esperados.get(i), arquivo);
+                }
             }
         }
     }
@@ -104,12 +112,15 @@ public class ImporterFileTest {
 
     @Test(dataProvider = "arquivosLastSheet")
     public void validaLastSheet(File arquivo, boolean lastSheet, int afterLine, List<FileBean> esperados) throws Exception {
-        try (final ExcelParser<FileBean> excelParser = new ExcelParser<>(FileBean.class, arquivo, afterLine, lastSheet, ImporterXLSXType.DEFAULT)) {
-            excelParser.setDateStringPattern(DD_MM_YYYY);
+        for (Locale locale : LOCALES) {
+            Locale.setDefault(locale);
+            try (final ExcelParser<FileBean> excelParser = new ExcelParser<>(FileBean.class, arquivo, afterLine, lastSheet, ImporterXLSXType.DEFAULT)) {
+                excelParser.setDateStringPattern(DD_MM_YYYY);
 
-            final List<FileBean> beans = excelParser.parse();
-            for (int i = 0; i < beans.size(); i++) {
-                assertFileBeanEquals(beans.get(i), esperados.get(i), arquivo);
+                final List<FileBean> beans = excelParser.parse();
+                for (int i = 0; i < beans.size(); i++) {
+                    assertFileBeanEquals(beans.get(i), esperados.get(i), arquivo);
+                }
             }
         }
     }
@@ -134,18 +145,21 @@ public class ImporterFileTest {
 
     @Test(dataProvider = "arquivosSheet")
     public void validaSheet(File arquivo, int afterLine, List<List<FileBean>> sheets) throws Exception {
-        try (final ExcelParser<FileBean> excelParser = new ExcelParser<>(FileBean.class, arquivo, afterLine)) {
-            excelParser.setDateStringPattern(DD_MM_YYYY);
+        for (Locale locale : LOCALES) {
+            Locale.setDefault(locale);
+            try (final ExcelParser<FileBean> excelParser = new ExcelParser<>(FileBean.class, arquivo, afterLine)) {
+                excelParser.setDateStringPattern(DD_MM_YYYY);
 
-            for (int sheetNumber = 0; sheetNumber < sheets.size(); sheetNumber++) {
-                excelParser.setSheetNumber(sheetNumber);
-                final List<FileBean> esperados = sheets.get(sheetNumber);
+                for (int sheetNumber = 0; sheetNumber < sheets.size(); sheetNumber++) {
+                    excelParser.setSheetNumber(sheetNumber);
+                    final List<FileBean> esperados = sheets.get(sheetNumber);
 
-                final List<FileBean> beans = excelParser.parse();
-                for (int i = 0; i < beans.size(); i++) {
-                    final FileBean atual = beans.get(i);
-                    final FileBean esperado = esperados.get(i);
-                    assertFileBeanEquals(atual, esperado, arquivo);
+                    final List<FileBean> beans = excelParser.parse();
+                    for (int i = 0; i < beans.size(); i++) {
+                        final FileBean atual = beans.get(i);
+                        final FileBean esperado = esperados.get(i);
+                        assertFileBeanEquals(atual, esperado, arquivo);
+                    }
                 }
             }
         }
@@ -153,21 +167,24 @@ public class ImporterFileTest {
 
 	@Test(dataProvider = "arquivosSheet")
 	public void validaSheetWithDate(File arquivo, int afterLine, List<List<FileBean>> sheets) throws Exception {
-		try (final ExcelParser<FileBean> excelParser = new ExcelParser<>(FileBean.class, arquivo, afterLine)) {
-			excelParser.setDateAsString(false);
+        for (Locale locale : LOCALES) {
+            Locale.setDefault(locale);
+            try (final ExcelParser<FileBean> excelParser = new ExcelParser<>(FileBean.class, arquivo, afterLine)) {
+                excelParser.setDateAsString(false);
 
-			for (int sheetNumber = 0; sheetNumber < sheets.size(); sheetNumber++) {
-				excelParser.setSheetNumber(sheetNumber);
-				final List<FileBean> esperados = sheets.get(sheetNumber);
+                for (int sheetNumber = 0; sheetNumber < sheets.size(); sheetNumber++) {
+                    excelParser.setSheetNumber(sheetNumber);
+                    final List<FileBean> esperados = sheets.get(sheetNumber);
 
-				final List<FileBean> beans = excelParser.parse();
-				for (int i = 0; i < beans.size(); i++) {
-					final FileBean atual = beans.get(i);
-					final FileBean esperado = esperados.get(i);
-					assertFileBeanEquals(atual, esperado, arquivo);
-				}
-			}
-		}
+                    final List<FileBean> beans = excelParser.parse();
+                    for (int i = 0; i < beans.size(); i++) {
+                        final FileBean atual = beans.get(i);
+                        final FileBean esperado = esperados.get(i);
+                        assertFileBeanEquals(atual, esperado, arquivo);
+                    }
+                }
+            }
+        }
 	}
 
     private void assertFileBeanEquals(FileBean atual, FileBean esperado, File file) {

--- a/src/test/java/br/com/tecsinapse/files/test/ImporterFileTest.java
+++ b/src/test/java/br/com/tecsinapse/files/test/ImporterFileTest.java
@@ -18,13 +18,13 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import com.google.common.base.Charsets;
+
 import br.com.tecsinapse.exporter.FileType;
 import br.com.tecsinapse.exporter.converter.TableCellConverter;
 import br.com.tecsinapse.exporter.importer.ExcelParser;
 import br.com.tecsinapse.exporter.importer.Importer;
 import br.com.tecsinapse.exporter.importer.ImporterXLSXType;
-
-import com.google.common.base.Charsets;
 
 public class ImporterFileTest {
 
@@ -70,7 +70,7 @@ public class ImporterFileTest {
 
             final List<FileBean> beans = importer.parse();
             for (int i = 0; i < beans.size(); i++) {
-                assertFileBeanEquals(beans.get(i), esperados.get(i));
+                assertFileBeanEquals(beans.get(i), esperados.get(i), arquivo);
             }
         }
     }
@@ -105,7 +105,7 @@ public class ImporterFileTest {
 
             final List<FileBean> beans = excelParser.parse();
             for (int i = 0; i < beans.size(); i++) {
-                assertFileBeanEquals(beans.get(i), esperados.get(i));
+                assertFileBeanEquals(beans.get(i), esperados.get(i), arquivo);
             }
         }
     }
@@ -142,20 +142,39 @@ public class ImporterFileTest {
                 for (int i = 0; i < beans.size(); i++) {
                     final FileBean atual = beans.get(i);
                     final FileBean esperado = esperados.get(i);
-                    assertFileBeanEquals(atual, esperado);
+                    assertFileBeanEquals(atual, esperado, arquivo);
                 }
             }
         }
     }
 
-    private void assertFileBeanEquals(FileBean atual, FileBean esperado) {
-        assertEquals(atual.cidade, esperado.cidade);
-        assertEquals(atual.estado, esperado.estado);
-        assertEquals(atual.data, esperado.data);
-        assertEquals(atual.vazia, esperado.vazia);
-        assertEquals(atual.inteiro, esperado.inteiro);
-        assertEquals(atual.decimal.compareTo(esperado.decimal), 0);
-        assertEquals(atual.numeroInteger, esperado.numeroInteger);
+	@Test(dataProvider = "arquivosSheet")
+	public void validaSheetWithDate(File arquivo, int afterLine, List<List<FileBean>> sheets) throws Exception {
+		try (final ExcelParser<FileBean> excelParser = new ExcelParser<>(FileBean.class, arquivo, afterLine)) {
+			excelParser.setDateAsString(false);
+
+			for (int sheetNumber = 0; sheetNumber < sheets.size(); sheetNumber++) {
+				excelParser.setSheetNumber(sheetNumber);
+				final List<FileBean> esperados = sheets.get(sheetNumber);
+
+				final List<FileBean> beans = excelParser.parse();
+				for (int i = 0; i < beans.size(); i++) {
+					final FileBean atual = beans.get(i);
+					final FileBean esperado = esperados.get(i);
+					assertFileBeanEquals(atual, esperado, arquivo);
+				}
+			}
+		}
+	}
+
+    private void assertFileBeanEquals(FileBean atual, FileBean esperado, File file) {
+        assertEquals(atual.cidade, esperado.cidade, file.getName());
+        assertEquals(atual.estado, esperado.estado, file.getName());
+        assertEquals(atual.data, esperado.data, file.getName());
+        assertEquals(atual.vazia, esperado.vazia, file.getName());
+        assertEquals(atual.inteiro, esperado.inteiro, file.getName());
+        assertEquals(atual.decimal.compareTo(esperado.decimal), 0, file.getName());
+        assertEquals(atual.numeroInteger, esperado.numeroInteger, file.getName());
     }
     
     @DataProvider(name = "filesWithHiddenSheet")


### PR DESCRIPTION
- XLS: Realizar leitura de data pelo valor numérico, sem conversão intermediária para string;
- XLSX: Utilizar pattern de data definido para reverter a data no formato String para uma data em formato LocalDate ou LocalDateTime (joda);
- Inclusão locales diferentes nos testes unitários de importação e exportação.

